### PR TITLE
feat: Update rating validation to allow ratings between 1 and 10

### DIFF
--- a/src/app/api/ratings/add/route.ts
+++ b/src/app/api/ratings/add/route.ts
@@ -17,8 +17,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
 
-    if (rating < 1 || rating > 5) {
-      return NextResponse.json({ error: 'Rating must be between 1 and 5' }, { status: 400 });
+    if (rating < 1 || rating > 10) {
+      return NextResponse.json({ error: 'Rating must be between 1 and 10' }, { status: 400 });
     }
 
     await dbConnect();


### PR DESCRIPTION
This commit updates the rating validation in the add rating API route to allow ratings between 1 and 10 instead of 1 and 5. This change ensures that users can provide a more accurate rating for movies or TV shows.